### PR TITLE
Add 'include_type_name' to 6.x write endpoints to ease ES7 migration

### DIFF
--- a/elasticsearch_dsl/__init__.py
+++ b/elasticsearch_dsl/__init__.py
@@ -11,6 +11,6 @@ from .analysis import analyzer, char_filter, normalizer, token_filter, tokenizer
 from .faceted_search import *
 from .wrappers import *
 
-VERSION = (6, 4, 0)
+VERSION = (6, 4, 1)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))

--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -30,7 +30,7 @@ class IndexTemplate(object):
 
     def save(self, using=None):
         es = connections.get_connection(using or self._index._using)
-        es.indices.put_template(name=self._template_name, body=self.to_dict())
+        es.indices.put_template(name=self._template_name, body=self.to_dict(), params={'include_type_name': 'true'})
 
 class Index(object):
     def __init__(self, name, doc_type=DEFAULT_DOC_TYPE, using='default'):
@@ -275,6 +275,9 @@ class Index(object):
         Any additional keyword arguments will be passed to
         ``Elasticsearch.indices.create`` unchanged.
         """
+        if 'params' not in kwargs:
+            kwargs['params'] = {}
+        kwargs['params']['include_type_name'] = 'true'
         self._get_connection(using).indices.create(index=self._name, body=self.to_dict(), **kwargs)
 
     def is_closed(self, using=None):
@@ -420,6 +423,9 @@ class Index(object):
         Any additional keyword arguments will be passed to
         ``Elasticsearch.indices.put_mapping`` unchanged.
         """
+        if 'params' not in kwargs:
+            kwargs['params'] = {}
+        kwargs['params']['include_type_name'] = 'true'
         return self._get_connection(using).indices.put_mapping(index=self._name, **kwargs)
 
     def get_mapping(self, using=None, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from os.path import join, dirname
 from setuptools import setup, find_packages
 
-VERSION = (6, 4, 0)
+VERSION = (6, 4, 1)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 


### PR DESCRIPTION
This PR includes `include_type_name` GET parameter to Elasticsearch calls which need it, in order to make Elasticsearch-DSL 6.X able to talk to an Elasticsearch 7 cluster.
More information on the [official Elasticsearch doc](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/removal-of-types.html#_schedule_for_removal_of_mapping_types).

Concerned write endpoint:
- create index
- put mapping
- put template

It allows the following Elasticsearch 6 to 7 migration process from an initial state where codebase and elastic cluster are 6.X:
- upgrade Elasticsearch clusters to 7.x while keeping Elasticsearch-DSL 6.x
- remove all explicit `_doc` occurrences from your project codebase
- upgrade Elasticsearch-DSL to 7.x

Fixes https://github.com/elastic/elasticsearch-dsl-py/issues/1381
